### PR TITLE
Ajuste na assinatura de papel do usuário

### DIFF
--- a/app/app/Modules/Usuario/Controller/Controller.php
+++ b/app/app/Modules/Usuario/Controller/Controller.php
@@ -90,7 +90,7 @@ class Controller extends BaseController
         return Response::json($response);
     }
 
-     /**
+    /**
      * @OA\Post(
      *      path="/api/usuario",
      *      tags={"Usuario"},
@@ -100,9 +100,9 @@ class Controller extends BaseController
      *          required=true,
      *          @OA\JsonContent(
      *              required={"nome", "papel", "status", "cep"},
-     *              @OA\Property(property="nome", type="string", example="Jacinto Pinto"),
-     *              @OA\Property(property="papel", type="string", example="mecanico || comercial || gestor_estoque || atendente"),
-     *              @OA\Property(property="status", type="string", example="ativo || inativo"),
+     *              @OA\Property(property="nome", type="string", example="Jhon Doe"),
+     *              @OA\Property(property="papel", type="string", example="mecanico,comercial,gestor_estoque,atendente"),
+     *              @OA\Property(property="status", type="string", example="ativo,inativo"),
      *          )
      *      ),
      *      @OA\Response(

--- a/app/app/Modules/Usuario/Dto/AtualizacaoDto.php
+++ b/app/app/Modules/Usuario/Dto/AtualizacaoDto.php
@@ -13,7 +13,7 @@ class AtualizacaoDto
     public function __construct(array $dados = [])
     {
         if (array_key_exists('papel', $dados)) {
-            $dados['role_id'] = Role::findByName($dados['papel'])->id;
+            $dados['role'] = Role::findByName($dados['papel']);
 
             unset($dados['papel']);
         }

--- a/app/app/Modules/Usuario/Dto/CadastroDto.php
+++ b/app/app/Modules/Usuario/Dto/CadastroDto.php
@@ -14,7 +14,7 @@ class CadastroDto
     {
         return [
             'nome'    => trim($this->nome),
-            'role_id' => Role::findByName(trim(strtolower($this->papel)))->id,
+            'role'    => Role::findByName(trim(strtolower($this->papel))),
             'status'  => trim($this->status),
         ];
     }

--- a/app/app/Modules/Usuario/Model/Usuario.php
+++ b/app/app/Modules/Usuario/Model/Usuario.php
@@ -6,8 +6,10 @@ use App\Traits\SoftDeletes;
 use Database\Factories\UsuarioFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\Traits\HasRoles;
 
 // use Illuminate\Support\Facades\Schema;
 
@@ -16,22 +18,26 @@ class Usuario extends Model
     /** @use HasFactory<\Database\Factories\UsuarioFactory> */
     use HasFactory;
     use SoftDeletes;
+    use HasRoles;
 
     public $table = 'usuario';
 
     public $timestamps = false;
 
+    protected $guard_name = 'web';
+
     protected $fillable = [
         'nome',
-        'role_id',
         'status',
         'excluido',
         'data_exclusao',
         'data_cadastro',
         'data_atualizacao'
-]   ;
+    ];
 
-    protected $hidden = [];
+    protected $hidden = [
+        'id'
+    ];
 
     protected function casts(): array
     {
@@ -42,9 +48,9 @@ class Usuario extends Model
         ];
     }
 
-    public function role(): HasOne
+    public function role(): BelongsTo
     {
-        return $this->hasOne(Role::class, 'id', 'role_id');
+        return $this->belongsTo(Role::class, 'role_id');
     }
 
     protected static function newFactory(): UsuarioFactory

--- a/app/app/Modules/Usuario/Requests/AtualizacaoRequest.php
+++ b/app/app/Modules/Usuario/Requests/AtualizacaoRequest.php
@@ -30,9 +30,9 @@ class AtualizacaoRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'uuid' => ['required', 'uuid', 'exists:usuario,uuid'],
-            'nome' => ['sometimes', 'string', 'max:255', 'min:3'],
-            'papel' => ['sometimes', 'string', 'max:255', 'min:3', 'exists:roles,name'],
+            'uuid'   => ['required', 'uuid', 'exists:usuario,uuid'],
+            'nome'   => ['sometimes', 'string', 'max:255', 'min:3'],
+            'papel'  => ['sometimes', 'string', 'max:255', 'min:3', 'exists:roles,name'],
             'status' => ['sometimes', 'string', 'max:255', 'min:3', 'in:ativo,inativo'],
         ];
     }

--- a/app/database/factories/UsuarioFactory.php
+++ b/app/database/factories/UsuarioFactory.php
@@ -2,12 +2,8 @@
 
 namespace Database\Factories;
 
-use App\Enums\Papel;
 use App\Modules\Usuario\Enums\StatusUsuario;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
-use Spatie\Permission\Models\Role;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Modules\Usuario\Model\Usuario>
@@ -16,21 +12,11 @@ class UsuarioFactory extends Factory
 {
     protected $model = \App\Modules\Usuario\Model\Usuario::class;
 
-    public array $possiveisPapeis = [
-        Papel::MECANICO->value,
-        Papel::COMERCIAL->value,
-        Papel::ATENDENTE->value,
-        Papel::GESTOR_ESTOQUE->value,
-    ];
-
     public function definition(): array
     {
-        $papel = fake()->randomElement($this->possiveisPapeis);
-
         return [
             'nome'    => fake()->name(),
             'status'  => StatusUsuario::ATIVO->value,
-            'role_id' => Role::findByName($papel)->id,
         ];
     }
 }

--- a/app/database/migrations/0001_01_01_000003_create_users_table.php
+++ b/app/database/migrations/0001_01_01_000003_create_users_table.php
@@ -18,9 +18,6 @@ return new class extends Migration
             $table->uuid('uuid')->default(DB::raw('uuid_generate_v4()'))->unique();
             $table->string('nome');
 
-            $table->unsignedBigInteger('role_id');
-            $table->foreign('role_id')->references('id')->on('roles');
-
             $table->string('status');
 
             $table->boolean('excluido')->default(false);

--- a/app/tests/Feature/Modules/Usuario/UsuarioAtualizacaoTest.php
+++ b/app/tests/Feature/Modules/Usuario/UsuarioAtualizacaoTest.php
@@ -24,36 +24,29 @@ class UsuarioAtualizacaoTest extends TestCase
         $this->seed(PapelSeed::class);
     }
 
-    public function test_usuario_atendente_pode_ter_o_nome_atualizado(): void
+    public function test_usuario_pode_ter_o_nome_atualizado(): void
     {
         // Arrange
 
         $payload = [
             'nome'     => 'Atendente',
             'status'   => StatusUsuario::ATIVO->value,
-            'role_id'  => Role::findByName(Papel::ATENDENTE->value)->id
         ];
 
-        $usuario = Usuario::factory()->create($payload)->fresh();
-
-        unset($payload['role_id']);
-
-        $payload['papel'] = 'atendente';
+        $usuario = Usuario::factory()->create($payload)->assignRole(Papel::ATENDENTE->value)->fresh();
 
         // Act
 
-        $novoNome = 'nome atualizado';
-
-        $payload['nome'] = $novoNome;
-
-        $response = $this->putJson('/api/usuario/' . $usuario->uuid, $payload);
+        $response = $this->putJson('/api/usuario/' . $usuario->uuid, [
+            'nome' => 'novo',
+        ]);
 
         // Assert
 
         $response->assertOk();
         $this->assertDatabaseHas('usuario', [
             'uuid' => $usuario->uuid,
-            'nome' => $novoNome,
+            'nome' => 'novo',
         ]);
     }
 
@@ -65,20 +58,17 @@ class UsuarioAtualizacaoTest extends TestCase
         $payload = [
             'nome'     => 'Atendente',
             'status'   => StatusUsuario::ATIVO->value,
-            'role_id'  => Role::findByName(Papel::ATENDENTE->value)->id
         ];
 
-        $usuario = Usuario::factory()->create($payload)->fresh();
-
-        // limpa role_id por que o endpoint de atualiacao recebe como uma abtracao pela chave "papel" e resolve o id depois
-        unset($payload['role_id']);
+        $usuario = Usuario::factory()->create($payload)->assignRole(Papel::ATENDENTE->value)->fresh();
 
         // Act
 
         $papelDeMecanico = Role::findByName(Papel::MECANICO->value)->name;
-        $payload['papel'] = $papelDeMecanico;
 
-        $response = $this->putJson('/api/usuario/' . $usuario->uuid, $payload);
+        $response = $this->putJson('/api/usuario/' . $usuario->uuid, [
+            'papel' => $papelDeMecanico,
+        ]);
 
         // Assert
 
@@ -93,20 +83,17 @@ class UsuarioAtualizacaoTest extends TestCase
         $payload = [
             'nome'     => 'Atendente',
             'status'   => StatusUsuario::ATIVO->value,
-            'role_id'  => Role::findByName(Papel::ATENDENTE->value)->id
         ];
 
-        $usuario = Usuario::factory()->create($payload)->fresh();
-
-        // limpa role_id por que o endpoint de atualiacao recebe como uma abtracao pela chave "papel" e resolve o id depois
-        unset($payload['role_id']);
+        $usuario = Usuario::factory()->create($payload)->assignRole(Papel::ATENDENTE->value)->fresh();
 
         // Act
 
         $desativado = StatusUsuario::INATIVO->value;
-        $payload['status'] = $desativado;
 
-        $response = $this->putJson('/api/usuario/' . $usuario->uuid, $payload);
+        $response = $this->putJson('/api/usuario/' . $usuario->uuid, [
+            'status' => $desativado,
+        ]);
 
         // Assert
 

--- a/app/tests/Feature/Modules/Usuario/UsuarioListagemTest.php
+++ b/app/tests/Feature/Modules/Usuario/UsuarioListagemTest.php
@@ -7,7 +7,6 @@ use App\Modules\Usuario\Enums\StatusUsuario;
 use App\Modules\Usuario\Model\Usuario;
 use Database\Seeders\PapelSeed;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class UsuarioListagemTest extends TestCase
@@ -46,7 +45,6 @@ class UsuarioListagemTest extends TestCase
         $payload = [
             'nome'    => fake()->name(),
             'status'  => StatusUsuario::ATIVO->value,
-            'role_id' => Role::findByName(Papel::MECANICO->value)->id,
         ];
 
         $usuario = Usuario::factory()->create($payload)->fresh();

--- a/app/tests/Feature/Modules/Usuario/UsuarioRemocaoTest.php
+++ b/app/tests/Feature/Modules/Usuario/UsuarioRemocaoTest.php
@@ -31,7 +31,6 @@ class UsuarioRemocaoTest extends TestCase
         $payload = [
             'nome'    => 'Atendente',
             'status'  => StatusUsuario::ATIVO->value,
-            'role_id' => Role::findByName(Papel::ATENDENTE->value)->id,
         ];
 
         $usuario = Usuario::factory()->create($payload)->fresh();


### PR DESCRIPTION
Removi a coluna `role_id` da tabela `usuario` para que a assinatura de papel seja feita de forma que aproveitemos as praticidades da biblioteca Laravel permissions. Com as alterações, o gerenciamento de papeis de usuário ficam na tabela pivot `model_has_roles`, que é a tabela que é gerenciada através da biblioteca Laravel permissions.

Refiz a doc e os testes. Tudo OK.

Como testar?

1. Baixe a branch.
2. Reconstrua o banco de dados, pois foram feitas alterações na tabela `usuario`
3. Execute os testes de usuário:
    - `docker exec -it oficina_soat_php php artisan test --testsuite=Feature --filter=UsuarioCadastroTest`
    - `docker exec -it oficina_soat_php php artisan test --testsuite=Feature --filter=UsuarioListagemTest`
    - `docker exec -it oficina_soat_php php artisan test --testsuite=Feature --filter=UsuarioAtualizacaoTest`
    - `docker exec -it oficina_soat_php php artisan test --testsuite=Feature --filter=UsuarioRemocaoTest`
4. Teste pela interface swagger